### PR TITLE
fix for using openAtLandingIndex

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -141,7 +141,8 @@ window.gianniAccordion = (function () {
         'elementSelected': [],
         'elementOpened': [],
         'elementUnselected': [],
-        'elementClosed': []
+        'elementClosed': [],
+        'elementSelectedAtLanding': []
       };
       this.transitionendevent = this.transitionendEventName();
       this.oneAtATime = true;


### PR DESCRIPTION
When using the `openAtLandingIndex` option, the script fire the event "elementSelectedAtLanding" which isn't in the this.events resulting in an "undefined" error at line 169 (from property `length` of the `callbacks` variable).